### PR TITLE
Simplify the docker image by removing the dnsutils dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,6 @@ RUN set -eux \
        iptables \
        iproute2 \
        dnsmasq \
-       dnsutils \
        wireguard-tools \
        ca-certificates \
        ipcalc \

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -131,7 +131,7 @@ resolve_host() {
 		return 0
 	fi
 	# Resolve via DNS.
-	resolved=$(dig a +short "${host}" | head -1)
+	resolved=$(getent ahosts "${host}" | awk 'NR==1 {print $1}')
 	if [ -z "${resolved}" ]; then
 		return 1
 	fi

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -131,7 +131,7 @@ resolve_host() {
 		return 0
 	fi
 	# Resolve via DNS.
-	resolved=$(getent ahosts "${host}" | awk 'NR==1 {print $1}')
+	resolved=$(getent ahostsv4 "${host}" | awk 'NR==1 {print $1}')
 	if [ -z "${resolved}" ]; then
 		return 1
 	fi


### PR DESCRIPTION
There was only one `dig` cmd being executed, which was replaced by the already installed `getent`.