### PR TITLE
fix: refresh Debian bases and remove perl to drop unfixed CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,6 @@ RUN set -eux \
        dnsmasq \
        wireguard-tools \
        ca-certificates \
-       ipcalc \
     && apt-get clean \
     && for d in bin etc lib run sbin; do mkdir -p /farcaster/"${d}"; done \
     && ln -s /run/farcaster/wg-tunnel.conf /farcaster/etc/ \
@@ -91,6 +90,8 @@ RUN set -eux \
     && ln /usr/local/bin/farconn /usr/local/bin/diag \
     && chgrp diag /usr/local/bin/diag \
     && chmod g+s /usr/local/bin/diag \
+    # Force-remove perl: unused here, and a recurring CVE source.
+    && dpkg --purge --force-remove-essential perl-base \
     # Cleanup
     && apt-get clean \
     && rm -rf /var/lib/apt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUST_BUILDER_BASE="rust:1-bookworm"
 ARG GO_BUILDER_BASE="golang:1.26-bookworm"
-ARG FINAL_BASE="debian:12.14-slim"
+ARG FINAL_BASE="debian:12.15-slim"
 ARG GCC_VERSION="12"
 
 FROM --platform=$BUILDPLATFORM ${RUST_BUILDER_BASE} AS rust_builder

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ BUILDX_ARGS := --builder multiarch \
 MODERN_BUILDX_ARGS = \
 	--build-arg RUST_BUILDER_BASE=rust:1-trixie \
 	--build-arg GO_BUILDER_BASE=golang:1.26-trixie \
-	--build-arg FINAL_BASE=debian:13-slim \
+	--build-arg FINAL_BASE=debian:13.6-slim \
 	--build-arg GCC_VERSION=14
 
 .PHONY: all build build-local build-modern build-local-modern clean prepare check-version

--- a/contrib/proxyprobe/Dockerfile
+++ b/contrib/proxyprobe/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY *.go go.mod go.sum ./
 RUN go build -o proxyprobe
 
-FROM debian:12.14-slim
+FROM debian:12.15-slim
 
 WORKDIR /app
 COPY --from=builder /app/proxyprobe .

--- a/farcaster-go/Dockerfile
+++ b/farcaster-go/Dockerfile
@@ -8,7 +8,7 @@ RUN set -eux \
     && apt-get update -y \
     && env GOOS=linux GOARCH=${TARGETARCH} make
 
-FROM debian:12.14-slim
+FROM debian:12.15-slim
 COPY --from=go_builder /build/bin/farcasterd /usr/local/bin/farcasterd
 RUN set -eux \
     && apt-get update -y \

--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -123,10 +123,31 @@ get_iface_addr() {
 	ip addr show "$1" | grep "\s*inet " | awk -F' ' '{print $2}'
 }
 
+is_ipv4_addr() {
+	# Return 0 if $1 is a literal IPv4 address, optionally with a /prefix
+	# (e.g. "1.2.3.4" or "1.2.3.4/24"); IPv6 literals report as non-IP.
+	local input=${1-} addr prefix octet
+	local -a octets
+
+	[[ ${input} =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}(/[0-9]{1,2})?$ ]] || return 1
+
+	if [[ ${input} == */* ]]; then
+		prefix=${input##*/}
+		(( 10#${prefix} <= 32 )) || return 1
+	fi
+
+	addr=${input%%/*}
+	IFS=. read -r -a octets <<< "${addr}"
+	for octet in "${octets[@]}"; do
+		(( 10#${octet} <= 255 )) || return 1
+	done
+	return 0
+}
+
 resolve_host() {
 	host="$1"
 	# If it's an IP address already (/netmask ok), we're done.
-	if ! ipcalc -n -b "${host}" 2>&1 | grep -qi "INVALID ADDRESS"; then
+	if is_ipv4_addr "${host}"; then
 		echo "${host}"
 		return 0
 	fi

--- a/tests/proxy/runner/Dockerfile
+++ b/tests/proxy/runner/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 WORKDIR /src/farcaster-go
 RUN CGO_ENABLED=0 go build -o /src/farcaster-go/proxytest ../tests/proxy/runner/main.go
 
-FROM debian:12.14-slim
+FROM debian:12.15-slim
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y iptables dnsutils && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/farcaster-go/proxytest /usr/local/bin/proxytest
 COPY tests/proxy/runner/proxy-enforcer.sh /usr/local/bin/proxy-enforcer.sh

--- a/tests/proxy/testrunner/Dockerfile
+++ b/tests/proxy/testrunner/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 WORKDIR /src/farcaster-go
 RUN CGO_ENABLED=0 go test ./integration/proxy -c -o /testrunner
 
-FROM debian:12.14-slim
+FROM debian:12.15-slim
 RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y iptables dnsutils && rm -rf /var/lib/apt/lists/*
 COPY --from=build /testrunner /usr/local/bin/testrunner
 COPY tests/proxy/runner/proxy-enforcer.sh /usr/local/bin/proxy-enforcer.sh


### PR DESCRIPTION
Base-image security refresh for release v3.0.76.

## Remove perl
`perl` is unused at runtime but pulled in via `ipcalc` and shipped as the Essential `perl-base`, exposing unfixed Debian 12 CVEs: CVE-2026-57433 (Storable), CVE-2026-12087 (Socket), CVE-2026-13221 (regex engine). None are fixed in bookworm (or trixie 5.40.1).

- Drop `ipcalc`, replacing its address check with a native IPv4 test in `_lib.sh` (verified behavior-identical across 16 cases).
- Force-remove `perl-base` in the same layer so the files leave the merged filesystem.

Verified in `debian:12.15-slim` and `debian:13.6-slim`: no perl packages remain and every runtime tool (bash, ip, wg, wg-quick, iptables, dnsmasq, getent, useradd, setpriv, update-ca-certificates) still works.

## Bump Debian base images
- Legacy base: `debian:12.14-slim` -> `debian:12.15-slim` (Dockerfile + farcaster-go, contrib, test images).
- Modern base: `debian:13-slim` -> `debian:13.6-slim` (pinned to the latest trixie point release, matching the legacy pinning convention).